### PR TITLE
Add hyperclick for references

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -32,9 +32,7 @@ module.exports = {
             wordRegExp: refRegExp,
             getSuggestionForWord(textEditor: TextEditor, text: string, range: Range): HyperclickSuggestion {
                 if(isValid(textEditor, text, range)) {
-                    console.log('valid')
                     var label = text.match(refRegExp)[1]
-                    console.log(label)
                     var callback
                     textEditor.scan(new RegExp(`\\\\label{${label}}`), ({stop, range}) => {
                         callback = () => textEditor.setCursorScreenPosition(range.start)

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,32 +1,48 @@
 'use babel'
 
 import path from 'path'
+var inputRegExp = /\\(?:input|include|includeonly|subfile){(.*)}/
+var refRegExp = /\\[fF]?[rR]ef{(.*)}/
+const providerName = "latex-hyperclick"
+
+function isValid(textEditor, text, range) {
+    return range.start !== range.end && textEditor.getGrammar().scopeName.startsWith("text.tex.latex")
+}
 
 module.exports = {
     getProvider() {
-        var inputRegExp = /\\(?:input|include|includeonly|subfile){(.*)}/
-        return {
-            providerName: "latex-hyperclick",
+        return [{
+            providerName: providerName,
             wordRegExp: inputRegExp,
             getSuggestionForWord(textEditor: TextEditor, text: string, range: Range): HyperclickSuggestion {
-                if(range.start === range.end) {
-                    return undefined
+                if(isValid(textEditor, text, range)) {
+                    var basedir = path.dirname(textEditor.getPath())
+                    var filenames = text.match(inputRegExp)[1].split(',').map(
+                        filename => path.resolve(basedir, !path.extname(filename) ? filename + '.tex' : filename))
+
+                    return {
+                        range: range,
+                        callback: filenames.length === 1 ? () => atom.workspace.open(filenames[0]) :
+                          filenames.map(filename => ({ title: filename, callback: () => atom.workspace.open(filename)}))
+                    }
                 }
-
-                if(!textEditor.getGrammar().scopeName.startsWith("text.tex.latex")) {
-                    return undefined
-                }
-
-                var basedir = path.dirname(textEditor.getPath())
-                var filenames = text.match(inputRegExp)[1].split(',').map(
-                  filename => path.resolve(basedir, !path.extname(filename) ? filename + '.tex' : filename))
-
-                return {
-                    range: range,
-                    callback: filenames.length === 1 ? () => atom.workspace.open(filenames[0]) :
-                      filenames.map(filename => ({ title: filename, callback: () => atom.workspace.open(filename)}))
-                };
             },
-        }
+        }, {
+            providerName: providerName,
+            wordRegExp: refRegExp,
+            getSuggestionForWord(textEditor: TextEditor, text: string, range: Range): HyperclickSuggestion {
+                if(isValid(textEditor, text, range)) {
+                    console.log('valid')
+                    var label = text.match(refRegExp)[1]
+                    console.log(label)
+                    var callback
+                    textEditor.scan(new RegExp(`\\\\label{${label}}`), ({stop, range}) => {
+                        callback = () => textEditor.setCursorScreenPosition(range.start)
+                        stop()
+                    })
+                    if (callback) return { range: range, callback: callback }
+                }
+            }
+        }]
     }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,7 +2,8 @@
 
 import path from 'path'
 var inputRegExp = /\\(?:input|include|includeonly|subfile){(.*)}/
-var refRegExp = /\\[fF]?[rR]ef{(.*)}/
+// Refence support for ref, fancyref, cleverref, hyperref, varioref
+var refRegExp = /\\(?:eqref|[fF]ref|pageref|[cvrR]ef|[aA]utoref\*?){(.*)}/
 const providerName = "latex-hyperclick"
 
 function isValid(textEditor, text, range) {
@@ -34,7 +35,7 @@ module.exports = {
                 if(isValid(textEditor, text, range)) {
                     var label = text.match(refRegExp)[1]
                     var callback
-                    textEditor.scan(new RegExp(`\\\\label{${label}}`), ({stop, range}) => {
+                    textEditor.scan(new RegExp(`\\\\label(?:cref)?{${label}}`), ({stop, range}) => {
                         callback = () => textEditor.setCursorScreenPosition(range.start)
                         stop()
                     })


### PR DESCRIPTION
Add support for `ref`, `fancyref`, `varioref`, `hyperref` and `cleverref`. Currently only references in the same file can be found since the search for `\label` is done with `TextEditor::scan`. 
